### PR TITLE
Bias correction now assumes that preferred frequencies go from 0 to (…

### DIFF
--- a/mrLoadRet/Plugin/GLM_v2/combineTransformOverlayFunctions/weightedMeanStd.m
+++ b/mrLoadRet/Plugin/GLM_v2/combineTransformOverlayFunctions/weightedMeanStd.m
@@ -35,7 +35,7 @@ stddev = sqrt( sum( array .* (indices - repmat(average,[1 1 1 nOverlays]) ).^2, 
 
 %correct partial-sampling bias
 if nargout == 4
-  popMean = 0:.1:10 ;
+  popMean = 0:.1:round(nOverlays*1.25) ;
   popStddev = .1:.1:5 ;
   nMeans = length(popMean);
   nStddevs = length(popStddev);


### PR DESCRIPTION
…nOverlays*1.25)
